### PR TITLE
PR for #55: Test MkDocs documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,22 @@ To get started, follow the steps below. For complete documentation, see the [Gen
 
 ### Getting started
 
-1. Clone the repository and move into the project directory:
+1. Clone the repository and move into its directory:
 
     ```sh
     git clone https://github.com/YourUsername/YourRepoName.git
     cd YourRepoName
     ```
 
-2. Run the setup script to create a local settings file (`local_env.sh`) and populate input files:
+2. Run the setup script to create the local settings file (`local_env.sh`), verify that local executables are correctly installed, and populate input files:
 
     ```sh
     bash setup.sh
+    ```
+
+3. Run the `run_all.sh` script to check that the template runs without error:
+    ```
+    bash run_all.sh
     ```
 
 ### Running modules
@@ -38,16 +43,6 @@ Each module:
 - Reads inputs from its `/input/` directory (populated automatically via `get_inputs.sh`)
 - Runs code from its `/source/` directory
 - Writes outputs to its `/output/` directory
-
-### Running the whole project
-
-To execute the full project pipeline, run:
-
-```sh
-bash run_all.sh
-```
-
-This will run all modules sequentially.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,54 @@
-This repository is based on the GentzkowLabTemplate, copyright 2024 by Matthew Gentzkow and distributed under the [MIT license](https://github.com/gentzkow/GentzkowLabTemplate/blob/main/LICENSE.txt). See the GentzkowLabTemplate [wiki](https://github.com/gentzkow/GentzkowLabTemplate/wiki) for documentation.
+This repository is built on the [GentzkowLabTemplate](https://github.com/gentzkowlab/GentzkowLabTemplate), © 2024 by Matthew Gentzkow and distributed under the [MIT license](https://github.com/gentzkow/GentzkowLabTemplate/blob/main/LICENSE.txt). 
 
-# External links
+
+## External links
 
 Use this section to document resources external to this repository that are part of the project.
 
-# Setup
+## Running the repository
 
-Use this section for setup steps required to run the repository.
+To get started, follow the steps below. For complete documentation, see the [GentzkowLabTemplate Docs](https://gentzkowlab.github.io/GentzkowLabTemplate/).
 
-# Notes
+### Getting started
+
+1. Clone the repository and move into the project directory:
+
+    ```sh
+    git clone https://github.com/YourUsername/YourRepoName.git
+    cd YourRepoName
+    ```
+
+2. Run the setup script to create a local settings file (`local_env.sh`) and populate input files:
+
+    ```sh
+    bash setup.sh
+    ```
+
+### Running modules
+
+This repository is organized into modules, each located in a subdirectory like `1_data/`, `2_analysis/`, etc. Each module contains a `make.sh` script that runs the code in that module from beginning to end.
+
+To run a module, navigate into its folder and run:  
+
+```sh
+bash make.sh
+```
+
+Each module:
+- Reads inputs from its `/input/` directory (populated automatically via `get_inputs.sh`)
+- Runs code from its `/source/` directory
+- Writes outputs to its `/output/` directory
+
+### Running the whole project
+
+To execute the full project pipeline, run:
+
+```sh
+bash run_all.sh
+```
+
+This will run all modules sequentially.
+
+## Notes
 
 Use this section for additional information.


### PR DESCRIPTION
Closes #55.

This update revises the template README to include essential steps for running the repository and adds a pointer to our [documentation site](https://gentzkowlab.github.io/GentzkowLabTemplate/).